### PR TITLE
Node js renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ end
 - `#initialize(options={})`, which accepts the hash from `config.react.server_renderer_options`
 - `#render(component_name, props, prerender_options)` to return a string of HTML
 
-`react-rails` provides two renderer classes: `React::ServerRendering::ExecJSRenderer` and `React::ServerRendering::BundleRenderer`.
+`react-rails` provides three renderer classes: `React::ServerRendering::ExecJSRenderer`, `React::ServerRendering::BundleRenderer`, and `React::ServerRendering::NodeJSRenderer`.
 
 `ExecJSRenderer` offers two other points for extension:
 
@@ -419,6 +419,36 @@ end
 
 Any subclass of `ExecJSRenderer` may use those hooks (for example, `BundleRenderer` uses them to handle `console.*` on the server).
 
+`NodeJSRenderer` makes requests to an external server, making it easier to stub a browser environment such as
+```JSX
+const { JSDOM } = require("jsdom")
+const matchMediaPolyfill = require("mq-polyfill").default
+
+const { window } = new JSDOM("<!DOCTYPE html><html><body></body></html>", {
+  url: process.env.HOST_URL,
+  referrer: process.env.HOST_URL,
+  contentType: "text/html",
+  userAgent: "test/browser"
+})
+
+window.Date = global.Date
+global.window = window
+global.document = window.document
+global.navigator = window.navigator
+```
+
+to enable the `NodeJSRenderer`
+```ruby
+# config/application.rb
+module MyApp
+  class Application < Rails::Application
+    config.react.server_renderer = React::ServerRendering::NodeJRenderer
+    config.react.server_renderer_options = {
+      node_server_url: <URL for your node service>
+    }
+  end
+end
+```
 ## Controller Actions
 
 Components can also be server-rendered directly from a controller action with the custom `component` renderer. For example:

--- a/lib/react/rails/component_mount.rb
+++ b/lib/react/rails/component_mount.rb
@@ -31,7 +31,7 @@ module React
 
         prerender_options = options[:prerender]
         if prerender_options
-          block = Proc.new{ concat(prerender_component(name, props, prerender_options)) }
+          block = Proc.new{ concat(prerender_component(name, props, prerender_options).html_safe) }
         end
 
         html_options = options.reverse_merge(:data => {})

--- a/lib/react/server_rendering.rb
+++ b/lib/react/server_rendering.rb
@@ -1,6 +1,7 @@
 require 'connection_pool'
 require 'react/server_rendering/exec_js_renderer'
 require 'react/server_rendering/bundle_renderer'
+require 'react/server_rendering/node_js_renderer'
 
 module React
   module ServerRendering

--- a/lib/react/server_rendering/node_js_renderer.rb
+++ b/lib/react/server_rendering/node_js_renderer.rb
@@ -17,7 +17,8 @@ module React
         post = Net::HTTP::Post.new(@uri.path)
         post['Content-Type'] = 'application/json'
         post.set_form_data(component_name: component_name, props: props.to_json)
-        @http.request(@uri, post).body
+        response = @http.request(@uri, post)
+        response.body if response.code == "200"
       rescue Net::HTTP::Persistent::Error => err
         React::ServerRendering::PrerenderError.new(component_name, props, err)
       end

--- a/lib/react/server_rendering/node_js_renderer.rb
+++ b/lib/react/server_rendering/node_js_renderer.rb
@@ -1,0 +1,22 @@
+module React
+  module ServerRendering
+
+    # This renderer class makes a request to an external node service.
+    # Allows you to stub out a browser environment in node.js so you can render react components
+    # that have dependencies on window/document/jQuery etc
+    # Assumes all assets are loaded by the node server.
+    class NodeJSRenderer
+      # @context is not available using this class
+      def initialize(options={})
+        @node_server_url = options.fetch(:node_server_url, '')
+      end
+
+      def render(component_name, props, prerender_options)
+        props = props.to_json
+        HTTParty.get(@node_server_url, query: { component_name: component_name, props: props }).to_s
+      rescue ExecJS::ProgramError => err
+        raise React::ServerRendering::PrerenderError.new(component_name, props, err)
+      end
+    end
+  end
+end

--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'railties', '>= 3.2'
   s.add_dependency 'tilt'
   s.add_dependency 'babel-transpiler', '>=0.7.0'
-  s.add_dependency 'httparty'
+  s.add_runtime_dependency 'net-http-persistent', '~> 3.0'
 
   s.files = Dir[
     'lib/**/*',

--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'railties', '>= 3.2'
   s.add_dependency 'tilt'
   s.add_dependency 'babel-transpiler', '>=0.7.0'
+  s.add_dependency 'httparty'
 
   s.files = Dir[
     'lib/**/*',


### PR DESCRIPTION
Add a semi-generic ServerRendering class `NodeJSRenderer` to maintain a persistent connection with a NodeJS service.